### PR TITLE
feat: Add skip and take to the tracklists route

### DIFF
--- a/tldb/api/tracklists/resources.py
+++ b/tldb/api/tracklists/resources.py
@@ -17,9 +17,11 @@ class Tracklists(Resource):
         """
         List all tracklists
         """
+        skip = int(request.args.get("skip", 0))
+        take = int(request.args.get("take", 10))
         verbose = request.args.get("verbose") == "1"
 
-        database_response = self.table.get(verbose=verbose)
+        database_response = self.table.get(skip=skip, take=take, verbose=verbose)
 
         return list(database_response)
 

--- a/tldb/database/tracklist.py
+++ b/tldb/database/tracklist.py
@@ -14,9 +14,9 @@ class Tracklist:
     def __init__(self):
         self.table = r.db(DATABASE_NAME).table(TABLE_NAME)
 
-    def get(self, id=None, verbose=False):
+    def get(self, id=None, skip=0, take=DEFAULT_LIMIT, verbose=False):
         if id is None:
-            query = self.table.limit(DEFAULT_LIMIT)
+            query = self.table.skip(skip).limit(take)
         else:
             query = self.table.get(id)
 


### PR DESCRIPTION
This commit adds a naive implementation of pagination for the tracklists
route so that clients can page through every tracklist.  For now it is
just ordered by the table's key which is the ID but eventually we want
to index on name and date.