### PR TITLE
chore: Add an editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true


### PR DESCRIPTION
This commit adds an editorconfig file to enforce style consistency.
Indentation is set to four spaces to conform with the black style tool.